### PR TITLE
cmake in percona client expects path

### DIFF
--- a/percona-client.rb
+++ b/percona-client.rb
@@ -85,7 +85,7 @@ class PerconaClient < Formula
     # Do not build the server
     args << "-DWITHOUT_SERVER=1"
 
-    system "cmake", *args
+    system "cmake", ".", *args
     system "make"
     system "make", "install"
 


### PR DESCRIPTION
cmake v3.13.3 expects path to be specified explicitly https://gitlab.kitware.com/cmake/cmake/commit/27eb7c5bdb5bb8deefe1772675dc4819592bf036