### PR TITLE
Updated mafft (and don't disable multithreading)

### DIFF
--- a/mafft.rb
+++ b/mafft.rb
@@ -3,45 +3,21 @@ class Mafft < Formula
   homepage "https://mafft.cbrc.jp/alignment/software/"
   # doi "10.1093/nar/gkf436"
   # tag "bioinformatics"
-  # tag origin homebrew-science
+  # tag origin homebrew-core
   # tag derived
 
-  url "https://mafft.cbrc.jp/alignment/software/mafft-7.305-with-extensions-src.tgz"
-  sha256 "26fccbd7091edfe6528a0535d33738546ee57b4a3b6e43332ffc3323e29ff4d1"
-
-  fails_with :clang do
-    build 421
-    cause <<~EOS
-      Clang does not allow default arguments in out-of-line definitions of
-      class template members.
-      EOS
-  end
+  url "https://mafft.cbrc.jp/alignment/software/mafft-7.427-with-extensions-src.tgz"
+  sha256 "068abcbc20965cbfa4e14c138cbfbcd0d311874ac2fdde384a580ac774f40e26"
 
   def install
-    make_args = %W[CC=#{ENV.cc} CXX=#{ENV.cxx} CFAGS=#{ENV.cflags}
-                   CXXFLAGS=#{ENV.cxxflags} PREFIX=#{prefix} MANDIR=#{man1}]
-    make_args << "ENABLE_MULTITHREAD=" if MacOS.version <= :snow_leopard
-    make_args << "install"
-    cd "core" do
-      system "make", *make_args
-    end
-
-    cd "extensions" do
-      system "make", *make_args
-    end
-  end
-
-  def caveats
-    if MacOS.version <= :snow_leopard
-      <<~EOS
-        This build of MAFFT is not multithreaded on Snow Leopard
-        because its compiler does not support thread-local storage.
-      EOS
-    end
+    make_args = %W[CC=#{ENV.cc} CXX=#{ENV.cxx} PREFIX=#{prefix} install]
+    system "make", "-C", "core", *make_args
+    system "make", "-C", "extensions", *make_args
   end
 
   test do
     (testpath/"test.fa").write ">1\nA\n>2\nA"
-    system "mafft", "test.fa"
+    output = shell_output("#{bin}/mafft test.fa")
+    assert_match ">1\na\n>2\na", output
   end
 end


### PR DESCRIPTION
The previous formula had a nasty directive to disable multi-threading on certain MacOS versions. Unfortunately, on linux, it considers the MacOS version to be 0 ...

I have also updated mafft to a newer version, essentially copying the formula from homebrew-core