### PR TITLE
Java 11.0.4 cannot be downloaded since you need an oracle account. Us…

### DIFF
--- a/openjdk-11.rb
+++ b/openjdk-11.rb
@@ -4,10 +4,10 @@ class Openjdk11 < Formula
   # tag origin homebrew-core
   # tag derived
 
-  version "11.0.4"
-  url "https://download.oracle.com/otn/java/jdk/11.0.4+10/cf1bbcbf431a474eb9fc550051f4ee78/jdk-11.0.4_linux-x64_bin.tar.gz"
+  version "11.0.2"
+  url "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz"
   
-  sha256 "45962ed7a08d66775cb036e6f33cd576ecb1eab655c96dbe74851a3ebe1945fa"
+  sha256 "99be79935354f5c0df1ad293620ea36d13f48ec3ea870c838f20c504c9668b57"
 
   bottle :unneeded
   keg_only "this would clash with other JDKs (and java is selected via jenv anyway)"


### PR DESCRIPTION
…ing a public java.net link like what we have done for java12 formula