### PR TITLE
Do not attempt testing formulae that require ensembl-moonshine

### DIFF
--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -57,6 +57,7 @@ do
 done
 echo "Formulae to test (incl. reverse dependencies): ${ALL_FORMULAE[@]}"
 
+#echo \
 docker run ${USE_TTY:-} -i \
        "${MOUNTS[@]}" \
        --env HOMEBREW_NO_AUTO_UPDATE=1 \

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -62,6 +62,6 @@ docker run ${USE_TTY:-} -i \
        "${MOUNTS[@]}" \
        --env HOMEBREW_NO_AUTO_UPDATE=1 \
        muffato/ensembl-linuxbrew-basic-dependencies \
-       brew install --build-from-source "${ALL_FORMULAE[@]}"
+       /bin/bash -c "brew deps --union ${ALL_FORMULAE[*]} | if grep -q ensembl/moonshine/; then echo Test skipped because ensembl/moonshine is not available; else brew install --build-from-source ${ALL_FORMULAE[*]}; fi"
        #/bin/bash
 


### PR DESCRIPTION
```$ env TRAVIS_COMMIT_RANGE=HEAD^..HEAD travisci/harness.sh 
Testing changed files in HEAD^..HEAD
Tap name is ensembl/external
Changed files: mafft.rb
Formulae to test (incl. reverse dependencies): ensembl/external/mafft ensembl/external/prank ensembl/external/t-coffee
==> Installing mafft from ensembl/external
(...)
```

```$ env TRAVIS_COMMIT_RANGE=c9229f70635160aaf5ccb295f70c3b40dc2e8691..HEAD travisci/harness.sh 
Testing changed files in c9229f70635160aaf5ccb295f70c3b40dc2e8691..HEAD
Tap name is ensembl/external
Changed files: blast-281.rb boost.rb mafft.rb mash.rb openjdk-12.rb percona-client.rb repeatmasker.rb repeatmodeler.rb
Formulae to test (incl. reverse dependencies): ensembl/external/blast-281 ensembl/external/boost ensembl/external/mafft ensembl/external/mash ensembl/external/openjdk-12 ensembl/external/percona-client ensembl/external/repeatmasker ensembl/external/repeatmodeler ensembl/external/augustus ensembl/external/tophat ensembl/external/prank ensembl/external/t-coffee ensembl/external/kent ensembl/external/maker ensembl/external/repeatmodeler
Test skipped because ensembl/moonshine is not available
```