### PR TITLE
Feature/update all taps in docker

### DIFF
--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -17,15 +17,26 @@ fi
 echo "Testing changed files in $COMMIT_RANGE"
 
 # Tap information
+DOCKER_TAP_PATH="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl"
+# The tap being tested
 TAP_LOCAL_PATH="$PWD"
 TAP_DIR_NAME="$(basename "$TAP_LOCAL_PATH")"
-TAP_DOCKER_PATH="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/$TAP_DIR_NAME"
+TAP_DOCKER_PATH="$DOCKER_TAP_PATH/$TAP_DIR_NAME"
 TAP_NAME="ensembl/${TAP_DIR_NAME#homebrew-}"
 echo "Tap name is $TAP_NAME"
+# The other main Ensembl tap (needs to be downloaded)
+OTHER_TAP_NAME="homebrew-ensembl"
+OTHER_TAP_URL="https://github.com/Ensembl/$OTHER_TAP_NAME"
+OTHER_TAP_LOCAL_PATH="$PWD/.deps/$OTHER_TAP_NAME"
+OTHER_TAP_DOCKER_PATH="$DOCKER_TAP_PATH/$OTHER_TAP_NAME"
+rm -rf "$OTHER_TAP_LOCAL_PATH"
+mkdir -p "$OTHER_TAP_LOCAL_PATH"
+git clone --depth 1 "$OTHER_TAP_URL" "$OTHER_TAP_LOCAL_PATH"
 
 # List the mount points
 MOUNTS=()
 MOUNTS+=("-v" "$TAP_LOCAL_PATH:$TAP_DOCKER_PATH")
+MOUNTS+=("-v" "$OTHER_TAP_LOCAL_PATH:$OTHER_TAP_DOCKER_PATH")
 
 # Get the list of files that have changed
 CHANGED_FILES=()

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -18,7 +18,7 @@ echo "Testing changed files in $COMMIT_RANGE"
 
 # Tap information
 TAP_DIR_NAME="$(basename "$PWD")"
-TAP_PATH="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/$TAP_DIR_NAME"
+TAP_DOCKER_PATH="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/$TAP_DIR_NAME"
 TAP_NAME="ensembl/${TAP_DIR_NAME#homebrew-}"
 echo "Tap name is $TAP_NAME"
 
@@ -44,7 +44,7 @@ MOUNTS=()
 for filename in "${CHANGED_FILES[@]}"
 do
     ALL_FORMULAE+=("$TAP_NAME/${filename%.rb}")
-    MOUNTS+=("-v" "$PWD/$filename:$TAP_PATH/$filename")
+    MOUNTS+=("-v" "$PWD/$filename:$TAP_DOCKER_PATH/$filename")
 done
 
 # Get the list of formulae they are a dependency of
@@ -62,6 +62,6 @@ docker run ${USE_TTY:-} -i \
        "${MOUNTS[@]}" \
        --env HOMEBREW_NO_AUTO_UPDATE=1 \
        muffato/ensembl-linuxbrew-basic-dependencies \
-       /bin/bash -c "brew deps --union ${ALL_FORMULAE[*]} | if grep -q ensembl/moonshine/; then echo Test skipped because ensembl/moonshine is not available; else brew install --build-from-source ${ALL_FORMULAE[*]}; fi"
+       "$TAP_DOCKER_PATH/travisci/test_on_docker.sh" "${ALL_FORMULAE[@]}"
        #/bin/bash
 

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -17,10 +17,15 @@ fi
 echo "Testing changed files in $COMMIT_RANGE"
 
 # Tap information
-TAP_DIR_NAME="$(basename "$PWD")"
+TAP_LOCAL_PATH="$PWD"
+TAP_DIR_NAME="$(basename "$TAP_LOCAL_PATH")"
 TAP_DOCKER_PATH="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/$TAP_DIR_NAME"
 TAP_NAME="ensembl/${TAP_DIR_NAME#homebrew-}"
 echo "Tap name is $TAP_NAME"
+
+# List the mount points
+MOUNTS=()
+MOUNTS+=("-v" "$TAP_LOCAL_PATH:$TAP_DOCKER_PATH")
 
 # Get the list of files that have changed
 CHANGED_FILES=()
@@ -38,13 +43,11 @@ then
 fi
 echo "Changed files: ${CHANGED_FILES[@]}"
 
-# Transform the files into formula names and mount points
+# Transform the files into formula names
 ALL_FORMULAE=()
-MOUNTS=()
 for filename in "${CHANGED_FILES[@]}"
 do
     ALL_FORMULAE+=("$TAP_NAME/${filename%.rb}")
-    MOUNTS+=("-v" "$PWD/$filename:$TAP_DOCKER_PATH/$filename")
 done
 
 # Get the list of formulae they are a dependency of

--- a/travisci/test_on_docker.sh
+++ b/travisci/test_on_docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 brew deps --union "$@" | if grep -q ensembl/moonshine/
 then
     echo Test skipped because the formulae rely on ensembl/moonshine, which is not available:

--- a/travisci/test_on_docker.sh
+++ b/travisci/test_on_docker.sh
@@ -2,7 +2,8 @@
 
 brew deps --union "$@" | if grep -q ensembl/moonshine/
 then
-    echo Test skipped because ensembl/moonshine is not available
+    echo Test skipped because the formulae rely on ensembl/moonshine, which is not available:
+    brew deps --union "$@" | grep ensembl/moonshine/
 else
     brew install --build-from-source "$@"
 fi

--- a/travisci/test_on_docker.sh
+++ b/travisci/test_on_docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+brew deps --union "$@" | if grep -q ensembl/moonshine/
+then
+    echo Test skipped because ensembl/moonshine is not available
+else
+    brew install --build-from-source "$@"
+fi


### PR DESCRIPTION
@thibauthourlier found that some builds fail because they rely on dependencies that are not in the Docker image yet (e.g. when pushing changes across both homebrew-external and homebrew-ensembl). Here I make the Travis build download the homebrew-ensembl and mount it in the container, alongside the entire homebrew-external (which could also be out of date in the image).

I have also moved the bash commands that run in Docker to a separate script.

Unfortunately this partially solves https://travis-ci.org/Ensembl/homebrew-external/builds/610433385 . 
Without the moonshine detection, you would see this:
```
$ env TRAVIS_COMMIT_RANGE=ff853ad806c7e4b31bd32e70d5edafba86a679c0..4d3dc3277b6f6445176efaf626ee8714fd4dae56 travisci/harness.sh 
Testing changed files in ff853ad806c7e4b31bd32e70d5edafba86a679c0..4d3dc3277b6f6445176efaf626ee8714fd4dae56
Tap name is ensembl/external
Cloning into '/home/matthieu/workspace/src/brew/homebrew-external/.deps/homebrew-ensembl'...
remote: Enumerating objects: 86, done.
remote: Counting objects: 100% (86/86), done.
remote: Compressing objects: 100% (82/82), done.
remote: Total 86 (delta 30), reused 8 (delta 0), pack-reused 0
Unpacking objects: 100% (86/86), done.
Changed files: repeatmasker.rb
Formulae to test (incl. reverse dependencies): ensembl/external/repeatmasker ensembl/external/maker ensembl/external/repeatmodeler
Test skipped because the formulae rely on ensembl/moonshine, which is not available:
ensembl/moonshine/phrap
ensembl/moonshine/repbase
==> Installing repeatmasker from ensembl/external
==> Installing dependencies for ensembl/external/repeatmasker: ensembl/external/hmmer, jpeg, pcre, ensembl/external/blast, ensembl/external/rmblast, ensembl/external/trf, ensembl/moonshine/phrap and ensembl/moonshine/repbase
==> Installing ensembl/external/repeatmasker dependency: ensembl/external/hmmer
==> Downloading http://eddylab.org/software/hmmer3/3.1b2/hmmer-3.1b2.tar.gz
######################################################################## 100.0%
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/hmmer/3.1b2_1
==> make
==> make check
==> make install
🍺  /home/linuxbrew/.linuxbrew/Cellar/hmmer/3.1b2_1: 79 files, 18.6MB, built in 1 minute 16 seconds
==> Installing ensembl/external/repeatmasker dependency: jpeg
==> Downloading https://linuxbrew.bintray.com/bottles/jpeg-9c.x86_64_linux.bottle.tar.gz
######################################################################## 100.0%
==> Pouring jpeg-9c.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/jpeg/9c: 22 files, 4MB
...
```
and it then fails when attempting to install the moonshine dependencies.

But with the moonshine detection merged (#10) we now see:
```
$ env TRAVIS_COMMIT_RANGE=ff853ad806c7e4b31bd32e70d5edafba86a679c0..4d3dc3277b6f6445176efaf626ee8714fd4dae56 travisci/harness.sh 
Testing changed files in ff853ad806c7e4b31bd32e70d5edafba86a679c0..4d3dc3277b6f6445176efaf626ee8714fd4dae56
Tap name is ensembl/external
Cloning into '/home/matthieu/workspace/src/brew/homebrew-external/.deps/homebrew-ensembl'...
remote: Enumerating objects: 86, done.
remote: Counting objects: 100% (86/86), done.
remote: Compressing objects: 100% (82/82), done.
remote: Total 86 (delta 30), reused 8 (delta 0), pack-reused 0
Unpacking objects: 100% (86/86), done.
Changed files: repeatmasker.rb
Formulae to test (incl. reverse dependencies): ensembl/external/repeatmasker ensembl/external/maker ensembl/external/repeatmodeler
Test skipped because the formulae rely on ensembl/moonshine, which is not available:
ensembl/moonshine/phrap
ensembl/moonshine/repbase
```