### PR TITLE
Update graphviz-238.rb

### DIFF
--- a/graphviz-238.rb
+++ b/graphviz-238.rb
@@ -37,7 +37,10 @@ class Graphviz238 < Formula
   depends_on "librsvg"
   depends_on "freetype"
   depends_on "libpng"
-  depends_on :x11
+  
+  if build.with? "x11"
+    depends_on "libx11"
+  end
 
   fails_with :clang do
     build 318


### PR DESCRIPTION
Calling depends_on :x11 is disabled! Use depends_on specific X11 formula(e) instead.

This patch just overcomes the x:11 dependability; otherwise, brew will not tap it. 

There is a need to check if specific x11 lib this graphvix-238 formula requires. 