### PR TITLE
Add new dependency for HomologyAnnotation pipeline

### DIFF
--- a/fastme.rb
+++ b/fastme.rb
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Fastme < Formula
+  # tag "bioinformatics"
+  # tag origin homebrew-core
+  # tag derived
+  desc "Accurate and fast distance-based phylogeny inference program"
+  homepage "http://www.atgc-montpellier.fr/fastme/"
+  url "https://gite.lirmm.fr/atgc/FastME/raw/v2.1.6.1/tarball/fastme-2.1.6.1.tar.gz"
+  sha256 "ac05853bc246ccb3d88b8bc075709a82cfe096331b0f4682b639f37df2b30974"
+  version "2.1.6.1"
+
+  fails_with :clang # no OpenMP support
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.dist").write <<~EOS
+      4
+      A 0.0 1.0 2.0 4.0
+      B 1.0 0.0 3.0 5.0
+      C 2.0 3.0 0.0 6.0
+      D 4.0 5.0 6.0 0.0
+    EOS
+
+    system "#{bin}/fastme", "-i", "test.dist"
+    assert_predicate testpath/"test.dist_fastme_tree.nwk", :exist?
+  end
+end
+


### PR DESCRIPTION
`FastME` is required by `OrthoFinder`, a new software that we are aiming to include into our homology prediction system for the rapid release. The first stage is to add it to the `HomologyAnnotation` pipeline.